### PR TITLE
Fix BsmtFin_SF_1 (don't overwrite with BsmtFin_Type1)

### DIFF
--- a/R/make_ames.R
+++ b/R/make_ames.R
@@ -150,7 +150,7 @@ process_ames <- function(dat) {
       Bsmt_Exposure = factor(Bsmt_Exposure),
       BsmtFin_Type_1 = ifelse(is.na(BsmtFin_Type_1), "No_Basement", BsmtFin_Type_1),
       BsmtFin_Type_1 = factor(BsmtFin_Type_1),
-      BsmtFin_SF_1 = ifelse(is.na(BsmtFin_SF_1), 0, BsmtFin_Type_1),
+      BsmtFin_SF_1 = ifelse(is.na(BsmtFin_SF_1), 0, BsmtFin_SF_1),
       BsmtFin_Type_2 = ifelse(is.na(BsmtFin_Type_2), "No_Basement", BsmtFin_Type_2),
       BsmtFin_Type_2 = factor(BsmtFin_Type_2),
       BsmtFin_SF_2 = ifelse(is.na(BsmtFin_SF_2), 0, BsmtFin_SF_2),


### PR DESCRIPTION
This was probably a copy-paste bug. I noticed it when plotting all features against `Sale_Price`.

The right solution probably involves `dplyr::recode` / `recode_factor`, maybe with `dplyr::across`, so that this wouldn't have been able to happen. But I've spot-checked the adjacent values and they seem ok, so I'm leaving it at this for now.